### PR TITLE
tell gunicorn to look for https

### DIFF
--- a/sentry.conf.py
+++ b/sentry.conf.py
@@ -23,6 +23,7 @@ SENTRY_WEB_PORT = int(os.environ.get('PORT', 9000))
 SENTRY_WEB_OPTIONS = {
     'workers': 8,
     'worker_class': 'gevent',
+    'secure_scheme_headers': {'X-FORWARDED-PROTO':'https'}
 }
 
 SENTRY_URL_PREFIX = os.environ.get('SENTRY_URL_PREFIX', '')


### PR DESCRIPTION
Hey, on heroku you have to look for X-Forwarded-Proto header to check for https, and if you don't then all JS on site will not work under https:// scheme.

This commit tells gunicorn to look for the header
