### PR TITLE
Add some missing steps to the readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,12 +36,12 @@ Follow the steps below to get Sentry up and running on Heroku:
 
         heroku config:set ALLOWED_HOSTS=*
 
-5. Set the absolute URL to the Sentry root directory. The URL should not include
+6. Set the absolute URL to the Sentry root directory. The URL should not include
    a trailing slash. Replace the URL below with your application's URL::
 
         heroku config:set SENTRY_URL_PREFIX=https://sentry-example.herokuapp.com
 
-6. Deploy Sentry to Heroku::
+7. Deploy Sentry to Heroku::
 
         git push heroku master
 
@@ -49,11 +49,11 @@ Follow the steps below to get Sentry up and running on Heroku:
 
         heroku run "sentry --config=sentry.conf.py syncdb"
 
-7. Run Sentry's database migrations::
+9. Run Sentry's database migrations::
 
         heroku run "sentry --config=sentry.conf.py upgrade"
 
-8. Create a user account for yourself::
+10. Create a user account for yourself::
 
         heroku run "sentry --config=sentry.conf.py createsuperuser"
 

--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,10 @@ Follow the steps below to get Sentry up and running on Heroku:
 
         git push heroku master
 
+8. Run the syncdb command to do some initial database setup::
+
+        heroku run "sentry --config=sentry.conf.py syncdb"
+
 7. Run Sentry's database migrations::
 
         heroku run "sentry --config=sentry.conf.py upgrade"

--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Follow the steps below to get Sentry up and running on Heroku:
 5. Set the absolute URL to the Sentry root directory. The URL should not include
    a trailing slash. Replace the URL below with your application's URL::
 
-        heroku config:set SENTRY_URL_PREFIX=https://sentry.example.com
+        heroku config:set SENTRY_URL_PREFIX=https://sentry-example.herokuapp.com
 
 6. Deploy Sentry to Heroku::
 

--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,10 @@ Follow the steps below to get Sentry up and running on Heroku:
 
         heroku config:set SENTRY_KEY=$(python -c "import base64, os; print(base64.b64encode(os.urandom(40)).decode())")
 
+5. Set the ALLOWED_HOSTS config or you won't be able to connect::
+
+        heroku config:set ALLOWED_HOSTS=*
+
 5. Set the absolute URL to the Sentry root directory. The URL should not include
    a trailing slash. Replace the URL below with your application's URL::
 


### PR DESCRIPTION
I went through the bootstrapping process again recently, and ran into some missing steps. The weird thing was the `upgrade` command didn't work for me. I kept getting postgres errors. But running `syncdb` beforehand fixed it. I also ran `migrate` but I don't think I had to because the `upgrade` command also does that.