### PR TITLE
Fix typo in release link markup.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ Follow the steps below to get Sentry up and running on Heroku:
 
         git push heroku master
 
-7. Sentry's database migrations are automatically run as part release-phase_ ::
+7. Sentry's database migrations are automatically run as part of the Heroku `release phase`_ ::
 
         heroku run "sentry --config=sentry.conf.py upgrade --noinput"
 
@@ -66,7 +66,7 @@ Follow the steps below to get Sentry up and running on Heroku:
 
 That's it!
 
-.. _release-phase https://devcenter.heroku.com/articles/release-phase
+.. _release phase: https://devcenter.heroku.com/articles/release-phase
 
 
 


### PR DESCRIPTION
Fix the release link in the readme, which currently points to https://github.com/fastmonkeys/sentry-on-heroku#id1.